### PR TITLE
fix: average accumulated energy over T steps

### DIFF
--- a/predictive_coding/pc_layer.py
+++ b/predictive_coding/pc_layer.py
@@ -226,8 +226,8 @@ class PCLayer(nn.Module):
         return self._error_cache.get(layer_type, None)
 
     def get_energy(self) -> Optional[float]:
-        """Get the accumulated energy for the layer."""
-        return float(self._energy)
+        """Get the accumulated energy for the layer, averaged over T steps."""
+        return float(self._energy) / max(self.T, 1)
 
     def clear_energy(self):
         """Clear the stored energy and cached states for the layer."""


### PR DESCRIPTION
This pull request makes a small but important change to the `get_energy` method in `pc_layer.py`. The method now returns the accumulated energy averaged over T steps, instead of just the total energy.

- The `get_energy` method now divides the accumulated energy by the number of steps `T` , providing an average energy per step instead of the total.